### PR TITLE
Zip the VTK folder to a folder in the home dir

### DIFF
--- a/flowSimAuto.sh
+++ b/flowSimAuto.sh
@@ -23,6 +23,15 @@ run_sim(){
     foamToVTK
 }
 
+zip_results(){
+    OUT_DIR="~/testResults"
+    if [ ! -d "$OUT_DIR" ]; then
+        mkdir "$OUT_DIR"
+    fi
+    zip -r "${OUT_DIR}/${TEST_NAME}.zip" ./VTK
+}
+
 verify-valid-proj
 open_sim_dir
 run_sim
+zip_results


### PR DESCRIPTION
# What was the Problem?
We did not package the results from the sim to be easily transferable.

# What does this do to Fix the Problem?
I created a function that checks if the output dir, ~/testResults, exists. If it doesn't, we create it. From there, we write the contents of the VTK folder to a zip file with the project name to the output dir.