### PR TITLE
Store the initial dir that the user started at, return there after

### DIFF
--- a/flowSimAuto.sh
+++ b/flowSimAuto.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 declare -n TEST_NAME = $1
+STARTING_DIR=$pwd
 
 verify_valid_proj(){
     $TEST_NAME = ${TEST_NAME// }
@@ -36,3 +37,5 @@ verify_valid_proj
 open_sim_dir
 run_sim
 zip_results
+cd $STARTING_DIR
+


### PR DESCRIPTION
# What was the Problem?
The user was left in a different directory after the command ended, resulting in confusion.

# What does this do to Fix the Problem?
This stores the initial working dir before doing anything, then moves back to it after completion.